### PR TITLE
fix: added some more types to committer

### DIFF
--- a/crates/committer/src/patricia_merkle_tree/filled_node.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_node.rs
@@ -1,7 +1,10 @@
-use starknet_api::core::{ClassHash, Nonce};
-
 use crate::patricia_merkle_tree::types::{LeafDataTrait, PathToBottom};
 use crate::{hash::types::HashOutput, types::Felt};
+// TODO(Nimrod, 1/6/2024): Swap to starknet-types-core types once implemented.
+#[allow(dead_code)]
+pub(crate) struct ClassHash(pub Felt);
+#[allow(dead_code)]
+pub(crate) struct Nonce(pub Felt);
 
 #[allow(dead_code)]
 pub(crate) struct FilledNode<L: LeafDataTrait> {
@@ -31,7 +34,7 @@ pub(crate) struct EdgeData {
 #[allow(dead_code)]
 pub(crate) enum LeafData {
     StorageValue(Felt),
-    CompiledClassHash(Felt),
+    CompiledClassHash(ClassHash),
     StateTreeTuple {
         class_hash: ClassHash,
         contract_state_root_hash: Felt,


### PR DESCRIPTION
The hash version is required because I think that we want python to be the source of truth.
It's being used [here](https://github.com/starkware-industries/starkware/blob/dev/src/starkware/starknet/business_logic/fact_state/contract_class_objects.py#L110) and [here](https://github.com/starkware-industries/starkware/blob/dev/src/starkware/starknet/business_logic/fact_state/contract_state_objects.py#L87).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/11)
<!-- Reviewable:end -->
