### PR TITLE
chore: adding basic CLI interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +411,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "committer"
 version = "0.1.0-rc.0"
 dependencies = [
@@ -375,6 +456,7 @@ dependencies = [
 name = "committer_cli"
 version = "0.1.0-rc.0"
 dependencies = [
+ "clap",
  "pretty_assertions",
 ]
 
@@ -1019,7 +1101,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1572,6 +1654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,18 +1919,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1846,10 +1964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1858,10 +1988,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1870,16 +2012,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license-file = "LICENSE"
 
 [workspace.dependencies]
 pretty_assertions = "1.2.1"
+clap = { version = "4.5.4", features = ["cargo"] }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/crates/committer_cli/Cargo.toml
+++ b/crates/committer_cli/Cargo.toml
@@ -11,3 +11,6 @@ workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+
+[dependencies]
+clap.workspace = true

--- a/crates/committer_cli/src/args.rs
+++ b/crates/committer_cli/src/args.rs
@@ -1,0 +1,34 @@
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct StoragePrefix(pub u8);
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct LeafPrefixes {
+    pub(crate) storage: StoragePrefix,
+    pub(crate) contract_state: StoragePrefix,
+    pub(crate) class: StoragePrefix,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct NodePrefixes {
+    pub(crate) edge: StoragePrefix,
+    pub(crate) sibling: StoragePrefix,
+    pub(crate) binary: StoragePrefix,
+    pub(crate) empty: StoragePrefix,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+/// Holds all the information needed for the committer.
+pub(crate) enum InputArgs {
+    CurrentArgs {
+        input_path: String,
+        output_path: String,
+        class_hash_version: u8,
+        contract_state_hash_version: u8,
+        leaf_prefixes: LeafPrefixes,
+        node_prefixes: NodePrefixes,
+    },
+}

--- a/crates/committer_cli/src/main.rs
+++ b/crates/committer_cli/src/main.rs
@@ -1,20 +1,209 @@
-use std::env;
-use std::path::Path;
+mod args;
+
+use args::InputArgs;
+use clap::{command, value_parser, Arg, ArgMatches};
+use std::{collections::HashSet, path::Path};
+
+use crate::args::{LeafPrefixes, NodePrefixes, StoragePrefix};
 
 /// Main entry point of the committer CLI.
 fn main() {
-    // Open the input file.
-    let args: Vec<String> = env::args().collect();
-    let input_file_name = Path::new(&args[1]);
-    let output_file_name = Path::new(&args[2]);
-    assert!(
-        input_file_name.is_absolute() && output_file_name.is_absolute(),
-        "Given paths must be absolute"
+    let args = args();
+    match args {
+        InputArgs::CurrentArgs {
+            input_path,
+            output_path,
+            class_hash_version: _,
+            contract_state_hash_version: _,
+            leaf_prefixes: _,
+            node_prefixes: _,
+        } => {
+            let input_file_name = Path::new(&input_path);
+            let output_file_name = Path::new(&output_path);
+            assert!(
+                input_file_name.is_absolute() && output_file_name.is_absolute(),
+                "Given paths must be absolute."
+            );
+            // Business logic to be implemented here.
+            let output = std::fs::read(input_file_name).unwrap();
+            // Output to file.
+            std::fs::write(output_file_name, output).expect("Failed to write output");
+        }
+    }
+}
+fn create_args() -> ArgMatches {
+    command!()
+        .about("Given previous state tree skeleton and a state diff, computes the new commitment.")
+        .arg(
+            Arg::new("class_hash_version")
+                .long("class-hash-version")
+                .required(true)
+                .help("An input when hashing a new leaf at the contract class patricia tree.")
+                .value_name("Integer")
+                .value_parser(value_parser!(u8)),
+        )
+        .arg(
+            Arg::new("contract_state_hash_version")
+                .long("contract-state-hash-version")
+                .required(true)
+                .help("An input when hashing a leaf at the contract instance patricia tree.")
+                .value_name("Integer")
+                .value_parser(value_parser!(u8)),
+        )
+        .arg(
+            Arg::new("input_file")
+                .value_name("FILE")
+                .long("input-file")
+                .default_value("stdin")
+                .short('i'),
+        )
+        .arg(
+            Arg::new("output_file")
+                .value_name("FILE")
+                .long("output-file")
+                .default_value("stdout")
+                .short('o'),
+        )
+        .arg(
+            Arg::new("sibling_node_prefix")
+                .long("sibling-node-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize a sibling node."),
+        )
+        .arg(
+            Arg::new("empty_node_prefix")
+                .long("empty-node-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize an empty node."),
+        )
+        .arg(
+            Arg::new("edge_node_prefix")
+                .long("edge-node-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize an edge node."),
+        )
+        .arg(
+            Arg::new("binary_node_prefix")
+                .long("binary-node-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize a binary node."),
+        )
+        .arg(
+            Arg::new("storage_leaf_prefix")
+                .long("storage-leaf-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize a storage leaf."),
+        )
+        .arg(
+            Arg::new("contract_state_leaf_prefix")
+                .long("contract-state-leaf-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize a contract state leaf."),
+        )
+        .arg(
+            Arg::new("class_leaf_prefix")
+                .long("class-leaf-prefix")
+                .required(true)
+                .value_name("Integer")
+                .value_parser(value_parser!(u8))
+                .help("The prefix used to serialize a compiled class hash leaf."),
+        )
+        .get_matches()
+}
+
+fn args() -> InputArgs {
+    let args = create_args();
+
+    let error_message = "Should not fail as this argument is required or has a default value.";
+    let input_path = args
+        .get_one::<String>("input_file")
+        .expect(error_message)
+        .to_string();
+    let output_path = args
+        .get_one::<String>("output_file")
+        .expect(error_message)
+        .to_string();
+    let class_hash_version = *args
+        .get_one::<u8>("class_hash_version")
+        .expect(error_message);
+    let contract_state_hash_version = *args
+        .get_one::<u8>("contract_state_hash_version")
+        .expect(error_message);
+
+    let edge = StoragePrefix(*args.get_one::<u8>("edge_node_prefix").expect(error_message));
+    let empty = StoragePrefix(
+        *args
+            .get_one::<u8>("empty_node_prefix")
+            .expect(error_message),
+    );
+    let sibling = StoragePrefix(
+        *args
+            .get_one::<u8>("sibling_node_prefix")
+            .expect(error_message),
+    );
+    let binary = StoragePrefix(
+        *args
+            .get_one::<u8>("binary_node_prefix")
+            .expect(error_message),
     );
 
-    // Business logic to be implemented here.
-    let output = std::fs::read(input_file_name).unwrap();
+    // Make sure the prefixes are unique.
+    let expected_unique_nodes = 4;
+    assert_eq!(
+        HashSet::from([binary.0, sibling.0, empty.0, edge.0]).len(),
+        expected_unique_nodes
+    );
 
-    // Output to file.
-    std::fs::write(output_file_name, output).expect("Failed to write output");
+    let storage = StoragePrefix(
+        *args
+            .get_one::<u8>("storage_leaf_prefix")
+            .expect(error_message),
+    );
+    let contract_state = StoragePrefix(
+        *args
+            .get_one::<u8>("contract_state_leaf_prefix")
+            .expect(error_message),
+    );
+    let class = StoragePrefix(
+        *args
+            .get_one::<u8>("class_leaf_prefix")
+            .expect(error_message),
+    );
+
+    // Make sure the prefixes are unique.
+    let expected_unique_leaves = 3;
+    assert_eq!(
+        HashSet::from([storage.0, contract_state.0, class.0]).len(),
+        expected_unique_leaves
+    );
+
+    InputArgs::CurrentArgs {
+        input_path,
+        output_path,
+        class_hash_version,
+        contract_state_hash_version,
+        node_prefixes: NodePrefixes {
+            edge,
+            sibling,
+            binary,
+            empty,
+        },
+        leaf_prefixes: LeafPrefixes {
+            storage,
+            contract_state,
+            class,
+        },
+    }
 }


### PR DESCRIPTION
That's how it looks when running cargo run -- --help:
![image](https://github.com/starkware-libs/committer/assets/143319383/c04dbbcc-4d51-4435-a567-e6bf00dc0862)
Some explanation about the arguments:
1. Hash versions are required since it's used [here](https://github.com/starkware-industries/starkware/blob/dev/src/starkware/starknet/business_logic/fact_state/contract_class_objects.py#L110) and [here](https://github.com/starkware-industries/starkware/blob/dev/src/starkware/starknet/business_logic/fact_state/contract_state_objects.py#L87) and we want that python will be the source of truth for these values.
2. When serializing nodes and leaves from python we know from which type they are, that information is necessary when deserializing. The idea is that python (which serializes) will know the prefixes used to serialize and will send that information to rust which will help with deserializing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/16)
<!-- Reviewable:end -->
