### PR TITLE
feat: add serialize method to filled_node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,8 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "rstest",
+ "serde",
+ "serde_json",
  "starknet-types-core",
  "thiserror",
 ]
@@ -573,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ pretty_assertions = "1.2.1"
 rayon = "1.10.0"
 rstest = "0.17.0"
 starknet-types-core = { version = "0.0.11", features = ["hash"] }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.116"
 thiserror = "1.0.58"
 
 [workspace.lints.rust]

--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -17,4 +17,6 @@ rstest.workspace = true
 derive_more.workspace = true
 rayon.workspace = true
 starknet-types-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/committer/src/patricia_merkle_tree.rs
+++ b/crates/committer/src/patricia_merkle_tree.rs
@@ -3,6 +3,7 @@ pub mod filled_node;
 pub mod filled_tree;
 pub mod original_skeleton_node;
 pub mod original_skeleton_tree;
+pub mod serialized_node;
 pub mod types;
 pub mod updated_skeleton_node;
 pub mod updated_skeleton_tree;

--- a/crates/committer/src/patricia_merkle_tree/errors.rs
+++ b/crates/committer/src/patricia_merkle_tree/errors.rs
@@ -1,4 +1,5 @@
 // TODO(Amos, 01/04/2024): Add error types.
+
 #[derive(Debug)]
 pub(crate) enum OriginalSkeletonTreeError {}
 
@@ -10,7 +11,8 @@ pub(crate) enum UpdatedSkeletonTreeError {
     NonDroppedPointer(String),
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug, derive_more::Display)]
 pub(crate) enum FilledTreeError {
     MissingRoot,
+    SerializeError(#[from] serde_json::Error),
 }

--- a/crates/committer/src/patricia_merkle_tree/filled_node.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_node.rs
@@ -1,3 +1,8 @@
+use crate::patricia_merkle_tree::errors::FilledTreeError;
+use crate::patricia_merkle_tree::filled_tree::FilledTreeResult;
+use crate::patricia_merkle_tree::serialized_node::{
+    LeafCompiledClassToSerialize, SerializeNode, SERIALIZE_HASH_BYTES,
+};
 use crate::patricia_merkle_tree::types::{EdgeData, LeafDataTrait};
 use crate::{hash::hash_trait::HashOutput, types::Felt};
 // TODO(Nimrod, 1/6/2024): Swap to starknet-types-core types once implemented.
@@ -57,6 +62,80 @@ impl LeafDataTrait for LeafData {
                     && class_hash.0 == Felt::ZERO
                     && *contract_state_root_hash == Felt::ZERO
             }
+        }
+    }
+}
+
+impl LeafData {
+    /// Serializes the leaf data into a byte vector.
+    /// The serialization is done as follows:
+    /// - For storage values: serializes the value into a 32-byte vector.
+    /// - For compiled class hashes or state tree tuples: creates a  json string
+    ///   describing the leaf and cast it into a byte vector.
+    pub(crate) fn serialize(&self) -> Result<SerializeNode, FilledTreeError> {
+        match &self {
+            LeafData::StorageValue(value) => {
+                Ok(SerializeNode::StorageLeaf(value.as_bytes().to_vec()))
+            }
+
+            LeafData::CompiledClassHash(class_hash) => {
+                // Create a temporary object to serialize the leaf into a JSON.
+                let temp_object_to_json = LeafCompiledClassToSerialize {
+                    compiled_class_hash: class_hash.0,
+                };
+
+                // Serialize the leaf into a JSON.
+                let json = serde_json::to_string(&temp_object_to_json)?;
+
+                // Serialize the json into a byte vector.
+                Ok(SerializeNode::CompiledClassLeaf(
+                    json.into_bytes().to_owned(),
+                ))
+            }
+
+            LeafData::StateTreeTuple { .. } => {
+                todo!("implement.");
+            }
+        }
+    }
+}
+
+impl FilledNode<LeafData> {
+    /// This method serializes the filled node into a byte vector, where:
+    /// - For binary nodes: Concatenates left and right hashes.
+    /// - For edge nodes: Concatenates bottom hash, path, and path length.
+    /// - For leaf nodes: use leaf.serialize() method.
+    #[allow(dead_code)]
+    pub(crate) fn serialize(&self) -> FilledTreeResult<SerializeNode> {
+        match &self.data {
+            NodeData::Binary(BinaryData {
+                left_hash,
+                right_hash,
+            }) => {
+                // Serialize left and right hashes to byte arrays.
+                let left: [u8; SERIALIZE_HASH_BYTES] = left_hash.0.as_bytes();
+                let right: [u8; SERIALIZE_HASH_BYTES] = right_hash.0.as_bytes();
+
+                // Concatenate left and right hashes.
+                let serialized = [left, right].concat();
+                Ok(SerializeNode::Binary(serialized))
+            }
+
+            NodeData::Edge(EdgeData {
+                bottom_hash,
+                path_to_bottom,
+            }) => {
+                // Serialize bottom hash, path, and path length to byte arrays.
+                let bottom: [u8; SERIALIZE_HASH_BYTES] = bottom_hash.0.as_bytes();
+                let path: [u8; SERIALIZE_HASH_BYTES] = path_to_bottom.path.0.as_bytes();
+                let length: [u8; 1] = path_to_bottom.length.0.to_be_bytes();
+
+                // Concatenate bottom hash, path, and path length.
+                let serialized = [bottom.to_vec(), path.to_vec(), length.to_vec()].concat();
+                Ok(SerializeNode::Edge(serialized))
+            }
+
+            NodeData::Leaf(leaf_data) => leaf_data.serialize(),
         }
     }
 }

--- a/crates/committer/src/patricia_merkle_tree/filled_tree.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_tree.rs
@@ -51,3 +51,5 @@ impl<L: LeafDataTrait> FilledTree<L> for FilledTreeImpl<L> {
         }
     }
 }
+
+pub(crate) type FilledTreeResult<T> = Result<T, FilledTreeError>;

--- a/crates/committer/src/patricia_merkle_tree/serialized_node.rs
+++ b/crates/committer/src/patricia_merkle_tree/serialized_node.rs
@@ -1,0 +1,35 @@
+use crate::types::Felt;
+use serde::{Deserialize, Serialize};
+
+// Const describe the size of the serialized node.
+pub(crate) const SERIALIZE_HASH_BYTES: usize = 32;
+#[allow(dead_code)]
+pub(crate) const BINARY_BYTES: usize = 2 * SERIALIZE_HASH_BYTES;
+#[allow(dead_code)]
+pub(crate) const EDGE_LENGTH_BYTES: usize = 1;
+#[allow(dead_code)]
+pub(crate) const EDGE_PATH_BYTES: usize = 32;
+#[allow(dead_code)]
+pub(crate) const EDGE_BYTES: usize = SERIALIZE_HASH_BYTES + EDGE_PATH_BYTES + EDGE_LENGTH_BYTES;
+#[allow(dead_code)]
+pub(crate) const STORAGE_LEAF_SIZE: usize = SERIALIZE_HASH_BYTES;
+
+// TODO(Aviv, 17/4/2024): add CompiledClassLeaf size.
+// TODO(Aviv, 17/4/2024): add StateTreeLeaf size.
+
+/// Enum to describe the serialized node.
+#[allow(dead_code)]
+pub(crate) enum SerializeNode {
+    Binary(Vec<u8>),
+    Edge(Vec<u8>),
+    CompiledClassLeaf(Vec<u8>),
+    StorageLeaf(Vec<u8>),
+    StateTreeLeaf(Vec<u8>),
+}
+
+/// Temporary struct to serialize the leaf CompiledClass.
+/// Required to comply to existing storage layout.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct LeafCompiledClassToSerialize {
+    pub(crate) compiled_class_hash: Felt,
+}

--- a/crates/committer/src/types.rs
+++ b/crates/committer/src/types.rs
@@ -1,6 +1,9 @@
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::{Felt as StarknetTypesFelt, FromStrError};
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Default, Hash, derive_more::Add)]
+#[derive(
+    Eq, PartialEq, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize, derive_more::Add,
+)]
 pub(crate) struct Felt(StarknetTypesFelt);
 
 #[macro_export]
@@ -48,5 +51,9 @@ impl Felt {
     /// Parse a hex-encoded number into `Felt`.
     pub(crate) fn from_hex(hex_string: &str) -> Result<Self, FromStrError> {
         Ok(StarknetTypesFelt::from_hex(hex_string)?.into())
+    }
+
+    pub(crate) fn as_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes_be()
     }
 }


### PR DESCRIPTION
This pull request introduces a serialization method for filled nodes in the Patricia Merkle tree implementation. The serialise method is implemented for the FilledNode type, allowing the conversion of filled nodes into byte vectors.

The method serializes the filled node into a byte vector according to the following rules:

For binary nodes: Concatenates the left and right hashes.
For edge nodes: Concatenates the bottom hash, path, and path length.
For leaf nodes: Concatenates the node's hash.
This functionality enhances the usability of the filled node struct by providing a convenient way to serialize its data for storage or transmission.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/18)
<!-- Reviewable:end -->
