### PR TITLE
Aviv/build serislize trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 target
 */.vscode/*
 *.DS_Store
+.vscode/settings.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "starknet-types-core",
+ "thiserror",
 ]
 
 [[package]]
@@ -614,6 +615,26 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ derive_more = "0.99.17"
 pretty_assertions = "1.2.1"
 rstest = "0.17.0"
 starknet-types-core = { version = "0.0.11", features = ["hash"] }
+thiserror = "1.0"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -16,3 +16,4 @@ rstest.workspace = true
 [dependencies]
 derive_more.workspace = true
 starknet-types-core.workspace = true
+thiserror.workspace = true

--- a/crates/committer/src/storage/errors.rs
+++ b/crates/committer/src/storage/errors.rs
@@ -1,2 +1,11 @@
+use derive_more::Display;
+
 #[derive(Debug)]
 pub(crate) enum StorageError {}
+
+#[derive(thiserror::Error, Debug, Display)]
+#[allow(dead_code)]
+pub(crate) enum SerdeError {
+    DeserializeError,
+    SerializeError,
+}

--- a/crates/committer/src/storage/serde_trait.rs
+++ b/crates/committer/src/storage/serde_trait.rs
@@ -1,0 +1,9 @@
+use crate::storage::errors::SerdeError;
+use crate::storage::storage_trait::{StorageError, StorageKey, StorageValue};
+
+pub(crate) trait serde_trait {
+    /// Serializes the given value.
+    fn serialize(&self) -> Result<StorageValue, SerdeError::Serialize>;
+    /// Deserializes the given value.
+    fn deserialize(vale: StorageValue) -> Result<Self, SerdeError::Deserialize>;
+}


### PR DESCRIPTION
This pull request introduces a new trait serde_trait along with error enums StorageError and SerdeError, and their respective implementations. These additions aim to provide a framework for serialization and deserialization operations within the storage module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/46)
<!-- Reviewable:end -->
