### PR TITLE
refactor: removed duplicate definitions of storage prefixes

### DIFF
--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/original_skeleton_calc.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/original_skeleton_calc.rs
@@ -13,6 +13,7 @@ use crate::patricia_merkle_tree::{
     original_skeleton_tree::node::OriginalSkeletonNode, types::NodeIndex,
 };
 use crate::storage::errors::StorageError;
+use crate::storage::storage_trait::create_db_key;
 use crate::storage::storage_trait::Storage;
 use crate::storage::storage_trait::StorageKey;
 use crate::storage::storage_trait::StoragePrefix;
@@ -205,8 +206,7 @@ impl OriginalSkeletonTreeImpl {
                 });
                 continue;
             }
-            let key =
-                StorageKey::from(subtree.root_hash.0).with_prefix(StoragePrefix::PatriciaNode);
+            let key = create_db_key(StoragePrefix::InnerNode, &subtree.root_hash.0.as_bytes());
             let val = storage.get(&key).ok_or(StorageError::MissingKey(key))?;
             subtrees_roots.push(FilledNode::deserialize(
                 &StorageKey::from(subtree.root_hash.0),

--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/original_skeleton_calc_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/original_skeleton_calc_test.rs
@@ -11,7 +11,7 @@ use rstest::rstest;
 use std::collections::HashMap;
 
 use crate::patricia_merkle_tree::types::TreeHeight;
-use crate::storage::storage_trait::{StorageKey, StoragePrefix, StorageValue};
+use crate::storage::storage_trait::{create_db_key, StorageKey, StoragePrefix, StorageValue};
 
 use super::OriginalSkeletonTreeImpl;
 
@@ -245,7 +245,7 @@ fn create_32_bytes_entry(simple_val: u8) -> Vec<u8> {
 }
 
 fn create_patricia_key(val: u8) -> StorageKey {
-    StorageKey(create_32_bytes_entry(val)).with_prefix(StoragePrefix::PatriciaNode)
+    create_db_key(StoragePrefix::InnerNode, &create_32_bytes_entry(val))
 }
 
 fn create_binary_val(left: u8, right: u8) -> StorageValue {

--- a/crates/committer/src/storage/storage_trait.rs
+++ b/crates/committer/src/storage/storage_trait.rs
@@ -29,22 +29,21 @@ pub(crate) trait Storage {
 }
 
 pub(crate) enum StoragePrefix {
-    PatriciaNode,
+    InnerNode,
+    StorageLeaf,
+    StateTreeLeaf,
+    CompiledClassLeaf,
 }
 
+/// Describes a storage prefix as used in Aerospike DB.
 impl StoragePrefix {
-    pub(crate) fn to_bytes(&self) -> &[u8] {
+    pub(crate) fn to_bytes(&self) -> &'static [u8] {
         match self {
-            Self::PatriciaNode => "patricia_node:".as_bytes(),
+            Self::InnerNode => b"patricia_node",
+            Self::StorageLeaf => b"starknet_storage_leaf",
+            Self::StateTreeLeaf => b"contract_state",
+            Self::CompiledClassLeaf => b"contract_class_leaf",
         }
-    }
-}
-
-impl StorageKey {
-    pub(crate) fn with_prefix(&self, prefix: StoragePrefix) -> Self {
-        let mut prefix = prefix.to_bytes().to_vec();
-        prefix.extend(&self.0);
-        StorageKey(prefix)
     }
 }
 
@@ -55,6 +54,6 @@ impl From<Felt> for StorageKey {
 }
 
 /// Returns a `StorageKey` from a prefix and a suffix.
-pub(crate) fn create_db_key(prefix: &[u8], suffix: &[u8]) -> StorageKey {
-    StorageKey([prefix.to_vec(), b":".to_vec(), suffix.to_vec()].concat())
+pub(crate) fn create_db_key(prefix: StoragePrefix, suffix: &[u8]) -> StorageKey {
+    StorageKey([prefix.to_bytes().to_vec(), b":".to_vec(), suffix.to_vec()].concat())
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/54)
<!-- Reviewable:end -->
