### PR TITLE
build: add python test command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,8 @@ version = "0.1.0-rc.0"
 dependencies = [
  "clap",
  "pretty_assertions",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/committer_cli/Cargo.toml
+++ b/crates/committer_cli/Cargo.toml
@@ -14,3 +14,5 @@ pretty_assertions.workspace = true
 
 [dependencies]
 clap.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/committer_cli/src/main.rs
+++ b/crates/committer_cli/src/main.rs
@@ -1,5 +1,8 @@
+use crate::tests::python_tests::PythonTest;
 use clap::{Args, Parser, Subcommand};
 use std::path::Path;
+
+pub mod tests;
 
 /// Committer CLI.
 #[derive(Debug, Parser)]
@@ -32,6 +35,15 @@ enum Command {
         #[clap(long)]
         contract_state_hash_version: String,
     },
+    PythonTest {
+        /// Test name.
+        #[clap(long)]
+        test_name: String,
+
+        /// Test inputs as a json.
+        #[clap(long)]
+        inputs: String,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -61,6 +73,20 @@ fn main() {
 
             // Output to file.
             std::fs::write(output_file_name, output).expect("Failed to write output");
+        }
+
+        Command::PythonTest { test_name, inputs } => {
+            // Create PythonTest from test_name.
+            let test = PythonTest::try_from(test_name)
+                .unwrap_or_else(|error| panic!("Failed to create PythonTest: {}", error));
+
+            // Run relevant test.
+            let output = test
+                .run(&inputs)
+                .unwrap_or_else(|error| panic!("Failed to run test: {}", error));
+
+            // Print test's output.
+            print!("{}", output);
         }
     }
 }

--- a/crates/committer_cli/src/tests.rs
+++ b/crates/committer_cli/src/tests.rs
@@ -1,0 +1,1 @@
+pub mod python_tests;

--- a/crates/committer_cli/src/tests/python_tests.rs
+++ b/crates/committer_cli/src/tests/python_tests.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+use thiserror;
+
+// Enum representing different Python tests.
+pub(crate) enum PythonTest {
+    ExampleTest,
+}
+
+/// Error type for PythonTest enum.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PythonTestError {
+    #[error("Unknown test name: {0}")]
+    UnknownTestName(String),
+    #[error("Failed to parse input: {0}")]
+    ParseInputError(#[from] serde_json::Error),
+}
+
+/// Implements conversion from a string to a `PythonTest`.
+impl TryFrom<String> for PythonTest {
+    type Error = PythonTestError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "example_test" => Ok(Self::ExampleTest),
+            _ => Err(PythonTestError::UnknownTestName(value)),
+        }
+    }
+}
+
+impl PythonTest {
+    /// Runs the test with the given arguments.
+    pub(crate) fn run(&self, input: &str) -> Result<String, PythonTestError> {
+        match self {
+            Self::ExampleTest => {
+                let example_input: HashMap<String, String> = serde_json::from_str(input)?;
+                Ok(example_test(example_input))
+            }
+        }
+    }
+}
+
+pub(crate) fn example_test(test_args: HashMap<String, String>) -> String {
+    let x = test_args.get("x").expect("Failed to get value for key 'x'");
+    let y = test_args.get("y").expect("Failed to get value for key 'y'");
+
+    format!("Calling example test with args: x: {}, y: {}", x, y)
+}


### PR DESCRIPTION
This PR adds a new module for Patricia Merkle Tree functionality and enables running Python tests within the Committer CLI. It introduces a PythonTest command to specify test names and inputs as JSON, executing tests and printing output to the console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/68)
<!-- Reviewable:end -->
