### PR TITLE
build: impl serialization for storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "bisection",
  "derive_more",
  "ethnum",
+ "hex",
  "pretty_assertions",
  "rstest",
  "serde",
@@ -411,6 +412,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bisection = "0.1.0"
 clap = { version = "4.5.4", features = ["cargo", "derive"] }
 derive_more = "0.99.17"
 ethnum = "1.5.0"
+hex = "0.4"
 pretty_assertions = "1.2.1"
 rstest = "0.17.0"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -18,6 +18,7 @@ async-recursion.workspace = true
 bisection.workspace = true
 derive_more.workspace = true
 ethnum.workspace = true
+hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true

--- a/crates/committer/src/storage.rs
+++ b/crates/committer/src/storage.rs
@@ -1,4 +1,4 @@
 pub mod errors;
-pub(crate) mod map_storage;
+pub mod map_storage;
 pub mod serde_trait;
 pub mod storage_trait;

--- a/crates/committer/src/storage/map_storage.rs
+++ b/crates/committer/src/storage/map_storage.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use crate::storage::storage_trait::{Storage, StorageKey, StorageValue};
+use serde::Serialize;
 
-pub(crate) struct MapStorage {
-    storage: HashMap<StorageKey, StorageValue>,
+#[derive(Serialize, Debug)]
+pub struct MapStorage {
+    pub storage: HashMap<StorageKey, StorageValue>,
 }
 
 impl Storage for MapStorage {


### PR DESCRIPTION
Introduces storage_serialize_test function to generate and serialize a MapStorage instance containing StorageKey and StorageValue pairs for values in the range 0..=99. Enabling serialization of MapStorage to JSON format using Serde.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/82)
<!-- Reviewable:end -->
