### PR TITLE
refactor:  move current_contract_state_leaves field

### DIFF
--- a/crates/committer/src/block_committer/input.rs
+++ b/crates/committer/src/block_committer/input.rs
@@ -26,7 +26,6 @@ pub struct StateDiff {
     pub address_to_class_hash: HashMap<ContractAddress, ClassHash>,
     pub address_to_nonce: HashMap<ContractAddress, Nonce>,
     pub class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
-    pub current_contract_state_leaves: HashMap<ContractAddress, ContractState>,
     pub storage_updates:
         HashMap<ContractAddress, HashMap<StarknetStorageKey, StarknetStorageValue>>,
 }
@@ -39,6 +38,7 @@ pub struct Input {
     pub state_diff: StateDiff,
     /// Height of class tree, contract tree and storage trees.
     pub tree_heights: TreeHeight,
+    pub current_contract_state_leaves: HashMap<ContractAddress, ContractState>,
     pub global_tree_root_hash: HashOutput,
     pub classes_tree_root_hash: HashOutput,
 }

--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/skeleton_forest.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/skeleton_forest.rs
@@ -55,7 +55,7 @@ impl<L: LeafData + std::clone::Clone, T: OriginalSkeletonTree<L>> OriginalSkelet
         )?;
         let contract_states = Self::create_lower_trees_skeleton(
             accessed_addresses,
-            &input.state_diff.current_contract_state_leaves,
+            &input.current_contract_state_leaves,
             &input.state_diff.storage_updates,
             &storage,
             input.tree_heights,

--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/skeleton_forest_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/skeleton_forest_test.rs
@@ -92,12 +92,6 @@ use super::OriginalSkeletonForest;
             create_binary_entry(154, 100),
         ]),
         state_diff: StateDiff {
-            current_contract_state_leaves: create_contract_leaves(&[
-                (3, 29),
-                (5, 29),
-                (6, 29),
-                (1, 55),
-            ]),
             storage_updates: create_storage_updates(&[
                 (3, &[8, 11, 13]),
                 (5, &[8, 11, 13]),
@@ -107,6 +101,12 @@ use super::OriginalSkeletonForest;
             ..Default::default()
         },
         tree_heights: TreeHeight(3),
+        current_contract_state_leaves: create_contract_leaves(&[
+            (3, 29),
+            (5, 29),
+            (6, 29),
+            (1, 55),
+        ]),
         global_tree_root_hash: HashOutput(Felt::from(254_u128)),
         classes_tree_root_hash: HashOutput(Felt::ZERO),
     }, OriginalSkeletonForest{

--- a/crates/committer_cli/src/parse_input/cast.rs
+++ b/crates/committer_cli/src/parse_input/cast.rs
@@ -97,13 +97,13 @@ impl TryFrom<RawInput> for Input {
                 address_to_class_hash,
                 address_to_nonce,
                 class_hash_to_compiled_class_hash,
-                current_contract_state_leaves,
                 storage_updates,
             },
             tree_heights: TreeHeight(raw_input.tree_heights),
             global_tree_root_hash: HashOutput(Felt::from_bytes_be_slice(
                 &raw_input.global_tree_root_hash,
             )),
+            current_contract_state_leaves,
             classes_tree_root_hash: HashOutput(Felt::from_bytes_be_slice(
                 &raw_input.classes_tree_root_hash,
             )),

--- a/crates/committer_cli/src/parse_input/read_test.rs
+++ b/crates/committer_cli/src/parse_input/read_test.rs
@@ -266,10 +266,10 @@ fn test_simple_input_parsing() {
             address_to_class_hash: expected_address_to_class_hash,
             address_to_nonce: expected_address_to_nonce,
             class_hash_to_compiled_class_hash: expected_class_hash_to_compiled_class_hash,
-            current_contract_state_leaves: expected_current_contract_state_leaves,
             storage_updates: expected_storage_updates,
         },
         tree_heights: expected_tree_heights,
+        current_contract_state_leaves: expected_current_contract_state_leaves,
         global_tree_root_hash: expected_global_tree_root_hash,
         classes_tree_root_hash: expected_classes_tree_root_hash,
     };

--- a/crates/committer_cli/src/tests/python_tests.rs
+++ b/crates/committer_cli/src/tests/python_tests.rs
@@ -174,7 +174,11 @@ pub(crate) fn parse_input_test() -> Result<String, PythonTestError> {
 
 fn create_output_to_python(actual_input: Input) -> String {
     let (storage_keys_hash, storage_values_hash) = hash_storage(&actual_input.storage);
-    let (state_diff_keys_hash, state_diff_values_hash) = hash_state_diff(&actual_input.state_diff);
+    let (state_diff_keys_hash, state_diff_values_hash) =
+        hash_state_diff_and_current_contract_state_leaves(
+            &actual_input.state_diff,
+            &actual_input.current_contract_state_leaves,
+        );
     format!(
         r#"
         {{
@@ -199,7 +203,7 @@ fn create_output_to_python(actual_input: Input) -> String {
             .state_diff
             .class_hash_to_compiled_class_hash
             .len(),
-        actual_input.state_diff.current_contract_state_leaves.len(),
+        actual_input.current_contract_state_leaves.len(),
         actual_input.state_diff.storage_updates.len(),
         actual_input.tree_heights.0,
         actual_input.global_tree_root_hash.0.to_bytes_be(),
@@ -213,7 +217,10 @@ fn create_output_to_python(actual_input: Input) -> String {
 
 /// Calculates the 'hash' of the parsed state diff in order to verify the state diff sent
 /// from python was parsed correctly.
-fn hash_state_diff(state_diff: &StateDiff) -> (Vec<u8>, Vec<u8>) {
+fn hash_state_diff_and_current_contract_state_leaves(
+    state_diff: &StateDiff,
+    current_contract_state_leaves: &HashMap<ContractAddress, ContractState>,
+) -> (Vec<u8>, Vec<u8>) {
     let (address_to_class_hash_keys_hash, address_to_class_hash_values_hash) =
         hash_address_to_class_hash(&state_diff.address_to_class_hash);
     let (address_to_nonce_keys_hash, address_to_nonce_values_hash) =
@@ -225,7 +232,7 @@ fn hash_state_diff(state_diff: &StateDiff) -> (Vec<u8>, Vec<u8>) {
     let (storage_updates_keys_hash, storage_updates_values_hash) =
         hash_storage_updates(&state_diff.storage_updates);
     let (current_contract_states_keys_hash, current_contract_states_values_hash) =
-        hash_current_contract_states(&state_diff.current_contract_state_leaves);
+        hash_current_contract_states(current_contract_state_leaves);
     let mut state_diff_keys_hash = xor_hash(
         &address_to_class_hash_keys_hash,
         &address_to_nonce_keys_hash,


### PR DESCRIPTION
motivation: current_contract_state_leaves is not part of the state diff- it shouldn't be associated with it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/97)
<!-- Reviewable:end -->
