### PR TITLE
refactor: update Python test input to accept Option<&str>

### DIFF
--- a/crates/committer_cli/src/main.rs
+++ b/crates/committer_cli/src/main.rs
@@ -43,7 +43,7 @@ enum Command {
 
         /// Test inputs as a json.
         #[clap(long)]
-        inputs: String,
+        inputs: Option<String>,
     },
 }
 
@@ -83,7 +83,7 @@ fn main() {
 
             // Run relevant test.
             let output = test
-                .run(&inputs)
+                .run(inputs.as_deref())
                 .unwrap_or_else(|error| panic!("Failed to run test: {}", error));
 
             // Print test's output.


### PR DESCRIPTION
- Changed Python test input type from `&str` to `Option<&str>`.
- This modification allows flexibility by handling cases where the input might not be provided.
- Adjusted the function signatures and updated relevant documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/102)
<!-- Reviewable:end -->
