### PR TITLE
test: forest to python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.59",
@@ -209,6 +209,8 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
 ]
@@ -219,10 +221,15 @@ version = "0.1.0-rc.0"
 dependencies = [
  "clap",
  "committer",
+ "derive_more",
  "ethnum",
  "pretty_assertions",
+ "rand",
+ "rand_distr",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -416,6 +423,12 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -485,6 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -674,6 +694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +752,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -854,6 +890,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.59",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,13 @@ ethnum = "1.5.0"
 hex = "0.4"
 pretty_assertions = "1.2.1"
 rand = "0.8.5"
+rand_distr = "0.4.3"
 rstest = "0.17.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 starknet-types-core = { version = "0.0.11", features = ["hash"] }
+strum = " 0.26.2"
+strum_macros = "0.26.2"
 thiserror = "1.0.58"
 tokio = { version = "1", features = ["full"] }
 

--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -9,6 +9,9 @@ description = "Computes and manages Starknet state."
 [lints]
 workspace = true
 
+[features]
+testing = []
+
 [dev-dependencies]
 pretty_assertions.workspace = true
 rand.workspace = true
@@ -20,8 +23,12 @@ bisection.workspace = true
 derive_more.workspace = true
 ethnum.workspace = true
 hex.workspace = true
+rand.workspace = true
+rstest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/committer/src/patricia_merkle_tree.rs
+++ b/crates/committer/src/patricia_merkle_tree.rs
@@ -5,5 +5,5 @@ pub mod original_skeleton_tree;
 pub mod types;
 pub mod updated_skeleton_tree;
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(feature = "testing", test))]
+pub mod test_utils;

--- a/crates/committer/src/patricia_merkle_tree/filled_tree/errors.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_tree/errors.rs
@@ -6,7 +6,7 @@ use crate::patricia_merkle_tree::{node_data::leaf::LeafData, types::NodeIndex};
 pub enum FilledTreeError<L: LeafData> {
     #[error("Deleted leaf at index {0:?} appears in the updated skeleton tree.")]
     DeletedLeafInSkeleton(NodeIndex),
-    #[error("Double update at node {index:?}. Existing value: {existing_value}.")]
+    #[error("Double update at node {index:?}. Existing value: {existing_value:?}.")]
     DoubleUpdate {
         index: NodeIndex,
         existing_value: Box<FilledNode<L>>,

--- a/crates/committer/src/patricia_merkle_tree/filled_tree/forest.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_tree/forest.rs
@@ -27,9 +27,9 @@ pub trait FilledForest<L: LeafData> {
 }
 
 pub struct FilledForestImpl {
-    storage_tries: HashMap<ContractAddress, FilledTreeImpl>,
-    contracts_trie: FilledTreeImpl,
-    classes_trie: FilledTreeImpl,
+    pub storage_tries: HashMap<ContractAddress, FilledTreeImpl>,
+    pub contracts_trie: FilledTreeImpl,
+    pub classes_trie: FilledTreeImpl,
 }
 
 impl FilledForest<LeafDataImpl> for FilledForestImpl {

--- a/crates/committer/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/committer/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -44,8 +44,8 @@ pub(crate) trait FilledTree<L: LeafData>: Sized {
     fn get_root_hash(&self) -> FilledTreeResult<HashOutput, L>;
 }
 
-pub(crate) struct FilledTreeImpl {
-    tree_map: HashMap<NodeIndex, FilledNode<LeafDataImpl>>,
+pub struct FilledTreeImpl {
+    pub tree_map: HashMap<NodeIndex, FilledNode<LeafDataImpl>>,
 }
 
 impl FilledTreeImpl {

--- a/crates/committer/src/patricia_merkle_tree/node_data/inner_node.rs
+++ b/crates/committer/src/patricia_merkle_tree/node_data/inner_node.rs
@@ -3,8 +3,11 @@ use crate::hash::hash_trait::HashOutput;
 use crate::patricia_merkle_tree::node_data::leaf::LeafData;
 use crate::patricia_merkle_tree::types::{NodeIndex, TreeHeight};
 use ethnum::U256;
+use strum_macros::{EnumDiscriminants, EnumIter};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "testing"), derive(EnumDiscriminants))]
+#[cfg_attr(any(test, feature = "testing"), strum_discriminants(derive(EnumIter)))]
 // A Patricia-Merkle tree node's data, i.e., the pre-image of its hash.
 pub enum NodeData<L: LeafData> {
     Binary(BinaryData),
@@ -20,7 +23,7 @@ pub struct BinaryData {
 
 // Wraps a U256. Maximal possible value is the longest path in a tree of height 251 (2 ^ 251 - 1).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct EdgePath(U256);
+pub struct EdgePath(pub U256);
 
 impl EdgePath {
     pub const BITS: u8 = TreeHeight::MAX.0;
@@ -57,9 +60,15 @@ impl From<&EdgePath> for U256 {
         path.0
     }
 }
+
 #[derive(Clone, Copy, Debug, Default, derive_more::Add, PartialEq, Eq, Hash)]
 pub struct EdgePathLength(pub u8);
 
+impl EdgePathLength {
+    /// [EdgePathLength] constant that represents the longest path (from some node) in a tree.
+    #[allow(clippy::as_conversions)]
+    pub const MAX: Self = Self(TreeHeight::MAX.0);
+}
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PathToBottom {
     pub path: EdgePath,

--- a/crates/committer/src/patricia_merkle_tree/node_data/leaf.rs
+++ b/crates/committer/src/patricia_merkle_tree/node_data/leaf.rs
@@ -5,6 +5,7 @@ use crate::hash::hash_trait::HashOutput;
 use crate::patricia_merkle_tree::filled_tree::node::{ClassHash, CompiledClassHash, Nonce};
 use crate::patricia_merkle_tree::types::NodeIndex;
 use crate::storage::db_object::DBObject;
+use strum_macros::{EnumDiscriminants, EnumIter};
 
 pub trait LeafData: Clone + Sync + Send + DBObject {
     /// Returns true if leaf is empty.
@@ -20,6 +21,8 @@ pub struct ContractState {
 
 #[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testing"), derive(EnumDiscriminants))]
+#[cfg_attr(any(test, feature = "testing"), strum_discriminants(derive(EnumIter)))]
 pub enum LeafDataImpl {
     StorageValue(Felt),
     CompiledClassHash(CompiledClassHash),

--- a/crates/committer/src/patricia_merkle_tree/test_utils.rs
+++ b/crates/committer/src/patricia_merkle_tree/test_utils.rs
@@ -1,3 +1,4 @@
+use crate::felt::Felt;
 use ethnum::U256;
 use rand::rngs::ThreadRng;
 use rand::Rng;
@@ -8,11 +9,7 @@ use crate::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
 
 impl From<u8> for SkeletonLeaf {
     fn from(value: u8) -> Self {
-        if value == 0 {
-            Self::Zero
-        } else {
-            Self::NonZero
-        }
+        Self::from(Felt::from(value))
     }
 }
 

--- a/crates/committer/src/patricia_merkle_tree/types.rs
+++ b/crates/committer/src/patricia_merkle_tree/types.rs
@@ -34,7 +34,7 @@ impl From<TreeHeight> for u8 {
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, derive_more::BitAnd, derive_more::Sub, PartialOrd, Ord,
 )]
-pub struct NodeIndex(U256);
+pub struct NodeIndex(pub U256);
 
 // Wraps a U256. Maximal possible value is the largest index in a tree of height 251 (2 ^ 252 - 1).
 impl NodeIndex {
@@ -56,7 +56,7 @@ impl NodeIndex {
         u128::MAX,
     ));
 
-    pub(crate) fn new(index: U256) -> Self {
+    pub fn new(index: U256) -> Self {
         assert!(index <= Self::MAX.0, "Index {index} is too large.");
         Self(index)
     }

--- a/crates/committer_cli/Cargo.toml
+++ b/crates/committer_cli/Cargo.toml
@@ -14,8 +14,13 @@ pretty_assertions.workspace = true
 
 [dependencies]
 clap.workspace = true
-committer = { path = "../committer" }
+committer = { path = "../committer" , features = ["testing"] }
+derive_more.workspace = true
 ethnum.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true

--- a/crates/committer_cli/src/filled_tree_output/filled_forest.rs
+++ b/crates/committer_cli/src/filled_tree_output/filled_forest.rs
@@ -4,11 +4,11 @@ use committer::patricia_merkle_tree::node_data::leaf::LeafDataImpl;
 use committer::storage::map_storage::MapStorage;
 
 #[allow(dead_code)]
-pub(crate) struct SerializedForest(FilledForestImpl);
+pub(crate) struct SerializedForest(pub(crate) FilledForestImpl);
 
 impl SerializedForest {
     #[allow(dead_code)]
-    fn forest_to_python(&self) -> Result<(), FilledForestError<LeafDataImpl>> {
+    pub(crate) fn forest_to_python(&self) -> Result<(), FilledForestError<LeafDataImpl>> {
         let mut storage = MapStorage::default();
         self.0.write_to_storage(&mut storage);
 
@@ -19,7 +19,7 @@ impl SerializedForest {
         let contract_storage_root_hash = self.0.get_contract_root_hash()?.0;
         println!("{}", contract_storage_root_hash.to_hex());
 
-        // Output the new compiled class storage root.
+        // Output the new compiled class root.
         let compiled_class_root_hash = self.0.get_compiled_class_root_hash()?.0;
         println!("{}", compiled_class_root_hash.to_hex());
 

--- a/crates/committer_cli/src/tests.rs
+++ b/crates/committer_cli/src/tests.rs
@@ -1,1 +1,2 @@
 pub mod python_tests;
+pub mod utils;

--- a/crates/committer_cli/src/tests/utils.rs
+++ b/crates/committer_cli/src/tests/utils.rs
@@ -1,0 +1,1 @@
+pub mod random_structs;

--- a/crates/committer_cli/src/tests/utils/random_structs.rs
+++ b/crates/committer_cli/src/tests/utils/random_structs.rs
@@ -1,0 +1,228 @@
+use committer::block_committer::input::ContractAddress;
+use committer::felt::Felt;
+use committer::hash::hash_trait::HashOutput;
+use committer::patricia_merkle_tree::filled_tree::forest::FilledForestImpl;
+use committer::patricia_merkle_tree::filled_tree::node::ClassHash;
+use committer::patricia_merkle_tree::filled_tree::node::CompiledClassHash;
+use committer::patricia_merkle_tree::filled_tree::node::FilledNode;
+use committer::patricia_merkle_tree::filled_tree::node::Nonce;
+use committer::patricia_merkle_tree::filled_tree::tree::FilledTreeImpl;
+use committer::patricia_merkle_tree::node_data::inner_node::BinaryData;
+use committer::patricia_merkle_tree::node_data::inner_node::EdgeData;
+use committer::patricia_merkle_tree::node_data::inner_node::NodeDataDiscriminants as NodeDataVariants;
+use committer::patricia_merkle_tree::node_data::inner_node::{
+    EdgePath, EdgePathLength, NodeData, PathToBottom,
+};
+use committer::patricia_merkle_tree::node_data::leaf::ContractState;
+use committer::patricia_merkle_tree::node_data::leaf::LeafDataImpl;
+use committer::patricia_merkle_tree::node_data::leaf::LeafDataImplDiscriminants as LeafDataVariants;
+use committer::patricia_merkle_tree::test_utils::get_random_u256;
+use committer::patricia_merkle_tree::types::NodeIndex;
+use ethnum::U256;
+use rand::prelude::IteratorRandom;
+use rand::Rng;
+use rand_distr::num_traits::ToPrimitive;
+use rand_distr::{Distribution, Geometric};
+use std::cmp::min;
+use std::collections::HashMap;
+use strum::IntoEnumIterator;
+
+pub trait RandomValue {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self;
+}
+
+pub trait DummyRandomValue {
+    fn dummy_random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self;
+}
+
+impl RandomValue for Felt {
+    fn random<R: Rng>(rng: &mut R, _max: Option<U256>) -> Self {
+        Felt::try_from(&get_random_u256(rng, U256::ONE, U256::from(&Felt::MAX) + 1))
+            .expect("Failed to create a random Felt")
+    }
+}
+
+impl RandomValue for HashOutput {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        HashOutput(Felt::random(rng, max))
+    }
+}
+
+impl RandomValue for LeafDataImpl {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        match LeafDataVariants::iter()
+            .choose(rng)
+            .expect("Failed to choose a random variant for LeafDataImpl")
+        {
+            LeafDataVariants::StorageValue => LeafDataImpl::StorageValue(Felt::random(rng, max)),
+            LeafDataVariants::CompiledClassHash => {
+                LeafDataImpl::CompiledClassHash(CompiledClassHash(Felt::random(rng, max)))
+            }
+            LeafDataVariants::ContractState => LeafDataImpl::ContractState(ContractState {
+                nonce: Nonce(Felt::random(rng, max)),
+                storage_root_hash: HashOutput::random(rng, max),
+                class_hash: ClassHash(Felt::random(rng, max)),
+            }),
+        }
+    }
+}
+
+impl RandomValue for BinaryData {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        Self {
+            left_hash: HashOutput::random(rng, max),
+            right_hash: HashOutput::random(rng, max),
+        }
+    }
+}
+
+impl RandomValue for PathToBottom {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        // Crate a random path and than calculate the length of the path.
+        let path = EdgePath::random(rng, max);
+        // TODO(Aviv, 27/6/2024): use a built in function once we migrate to a better big-integer library
+        // Randomly choose the number of real leading zeros in the path (up to the maximum possible).
+        // Real leading zero is a zero that refer to a left node, and not a padding zero.
+        let max_real_leading_zeros = path.0.leading_zeros() - EdgePath::MAX.0.leading_zeros();
+        let real_leading_zeros = std::cmp::min(
+            Geometric::new(0.5)
+                .expect("Failed to create random variable.")
+                .sample(rng)
+                .to_u32()
+                .expect("failed to cast random variable to u32"),
+            max_real_leading_zeros,
+        );
+        let length: u8 = (256_u32 - path.0.leading_zeros() + real_leading_zeros)
+            .try_into()
+            .expect("Leading zeros conversion to u8 failed");
+
+        Self {
+            path,
+            length: EdgePathLength(length),
+        }
+    }
+}
+
+impl RandomValue for EdgePath {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        // The maximum value is the maximum between max and EdgePath::MAX.
+        let max_value = match max {
+            Some(m) => min(m, EdgePath::MAX.0),
+            None => EdgePath::MAX.0,
+        };
+
+        Self(get_random_u256(rng, U256::ONE, max_value + 1))
+    }
+}
+
+impl RandomValue for EdgeData {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        Self {
+            bottom_hash: HashOutput::random(rng, max),
+            path_to_bottom: PathToBottom::random(rng, max),
+        }
+    }
+}
+
+impl RandomValue for NodeData<LeafDataImpl> {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        match NodeDataVariants::iter()
+            .choose(rng)
+            .expect("Failed to choose a random variant for NodeData")
+        {
+            NodeDataVariants::Binary => NodeData::Binary(BinaryData::random(rng, max)),
+            NodeDataVariants::Edge => NodeData::Edge(EdgeData::random(rng, max)),
+            NodeDataVariants::Leaf => NodeData::Leaf(LeafDataImpl::random(rng, max)),
+        }
+    }
+}
+
+impl RandomValue for NodeIndex {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        // The maximum value is the maximum between max and NodeIndex::MAX.
+        let max_value = match max {
+            Some(m) => min(m, NodeIndex::MAX.0),
+            None => NodeIndex::MAX.0,
+        };
+
+        Self::new(get_random_u256(rng, U256::ONE, max_value + 1))
+    }
+}
+
+impl RandomValue for FilledNode<LeafDataImpl> {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        Self {
+            data: NodeData::random(rng, max),
+            hash: HashOutput::random(rng, max),
+        }
+    }
+}
+
+impl RandomValue for ContractAddress {
+    fn random<R: Rng>(rng: &mut R, max: Option<U256>) -> Self {
+        ContractAddress(Felt::random(rng, max))
+    }
+}
+
+impl DummyRandomValue for FilledTreeImpl {
+    /// Generates a dummy random filled tree.
+    /// The tree contains up to max(m,101) random nodes in random indexes.
+    /// Do not necessary represent a valid tree.
+    fn dummy_random<R: Rng>(rng: &mut R, max_size: Option<U256>) -> Self {
+        // The maximum node number is the maximum between max and 101.
+        let max_node_number = match max_size {
+            Some(m) => m,
+            None => U256::from(101_u8),
+        }
+        .as_usize();
+
+        let mut nodes: Vec<(NodeIndex, FilledNode<LeafDataImpl>)> = (0..max_node_number)
+            .map(|_| {
+                (
+                    NodeIndex::random(rng, max_size),
+                    FilledNode::random(rng, max_size),
+                )
+            })
+            .collect();
+
+        nodes.push((NodeIndex::ROOT, FilledNode::random(rng, max_size)));
+
+        Self {
+            tree_map: nodes.into_iter().collect(),
+        }
+    }
+}
+
+impl DummyRandomValue for FilledForestImpl {
+    /// Generates a dummy random filled forest.
+    /// The forest contains max(m,98) dummy random storage trees,
+    /// a dummy random contract tree and a dummy random compiled class tree.
+    /// Does not necessary represent a valid forest.
+    fn dummy_random<R: Rng>(rng: &mut R, max_size: Option<U256>) -> Self {
+        // The maximum storage trees number is the maximum between max and 98.
+        // We also use this number to be the maximum tree size,
+        let max_trees_number = match max_size {
+            Some(m) => m,
+            None => U256::from(98_u8),
+        }
+        .as_usize();
+
+        let storage_tries: HashMap<ContractAddress, FilledTreeImpl> = (0..max_trees_number)
+            .map(|_| {
+                (
+                    ContractAddress::random(rng, max_size),
+                    FilledTreeImpl::dummy_random(rng, max_size),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        let contracts_trie = FilledTreeImpl::dummy_random(rng, max_size);
+        let classes_trie = FilledTreeImpl::dummy_random(rng, max_size);
+
+        Self {
+            storage_tries,
+            contracts_trie,
+            classes_trie,
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the following changes:

-RandomValue and DumpyRandomValue traits: Defines methods for generating random values for types like Felt, HashOutput, LeafDataImpl, BinaryData, PathToBottom, EdgePath, EdgePathLength, EdgeData, NodeData, NodeIndex, FilledNode, FilledTreeImpl and FilledForestImpl.

- Test that outputs a random FilledForestImpl to Python.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/143)
<!-- Reviewable:end -->
