### PR TITLE
fix: make all constants explicitly use the fixed actual tree height

### DIFF
--- a/crates/committer/src/patricia_merkle_tree/node_data/inner_node.rs
+++ b/crates/committer/src/patricia_merkle_tree/node_data/inner_node.rs
@@ -26,19 +26,26 @@ pub struct BinaryData {
 pub struct EdgePath(pub U256);
 
 impl EdgePath {
-    pub const BITS: u8 = TreeHeight::MAX.0;
-
     /// [EdgePath] constant that represents the longest path (from some node) in a tree.
     #[allow(clippy::as_conversions)]
     pub const MAX: Self = Self(U256::from_words(
-        u128::MAX >> (U256::BITS - Self::BITS as u32),
+        u128::MAX >> (U256::BITS - TreeHeight::MAX.0 as u32),
         u128::MAX,
     ));
 }
 
 impl From<U256> for EdgePath {
+    #[allow(clippy::as_conversions)]
     fn from(value: U256) -> Self {
-        assert!(value <= EdgePath::MAX.0, "Path {value:?} is too long.");
+        assert!(
+            value
+                <= Self(U256::from_words(
+                    u128::MAX >> (U256::BITS - TreeHeight::MAX.0 as u32),
+                    u128::MAX
+                ))
+                .0,
+            "Path {value:?} is too long."
+        );
         Self(value)
     }
 }
@@ -64,11 +71,6 @@ impl From<&EdgePath> for U256 {
 #[derive(Clone, Copy, Debug, Default, derive_more::Add, PartialEq, Eq, Hash)]
 pub struct EdgePathLength(pub u8);
 
-impl EdgePathLength {
-    /// [EdgePathLength] constant that represents the longest path (from some node) in a tree.
-    #[allow(clippy::as_conversions)]
-    pub const MAX: Self = Self(TreeHeight::MAX.0);
-}
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct PathToBottom {
     pub path: EdgePath,

--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/utils_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/utils_test.rs
@@ -76,7 +76,7 @@ fn test_split_leaves_big_tree(mut random: ThreadRng) {
         U256::ONE << 100,
     );
     test_split_leaves(
-        TreeHeight::MAX.into(),
+        TreeHeight::ACTUAL_HEIGHT.into(),
         NodeIndex::ROOT.into(),
         &[&left_leaf_indices[..], &right_leaf_indices[..]].concat(),
         left_leaf_indices.as_slice(),

--- a/crates/committer/src/patricia_merkle_tree/types.rs
+++ b/crates/committer/src/patricia_merkle_tree/types.rs
@@ -14,8 +14,9 @@ pub mod types_test;
 pub struct TreeHeight(pub(crate) u8);
 
 impl TreeHeight {
-    // TODO(Tzahi, 15/6/2024): Make height configurable for easy testing.
     pub const MAX: TreeHeight = TreeHeight(251);
+
+    pub const ACTUAL_HEIGHT: TreeHeight = Self::MAX;
 
     pub fn new(height: u8) -> Self {
         if height > Self::MAX.0 {
@@ -38,21 +39,22 @@ pub struct NodeIndex(pub U256);
 
 // Wraps a U256. Maximal possible value is the largest index in a tree of height 251 (2 ^ 252 - 1).
 impl NodeIndex {
-    pub const BITS: u8 = TreeHeight::MAX.0 + 1;
-
     /// [NodeIndex] constant that represents the root index.
     pub const ROOT: Self = Self(U256::ONE);
 
     #[allow(dead_code)]
     /// [NodeIndex] constant that represents the first leaf index.
     // TODO(Tzahi, 15/6/2024): Support height < 128 bits.
-    pub const FIRST_LEAF: Self = Self(U256::from_words(1_u128 << (Self::BITS - 1 - 128), 0));
+    pub const FIRST_LEAF: Self = Self(U256::from_words(
+        1_u128 << (TreeHeight::ACTUAL_HEIGHT.0 - 128),
+        0,
+    ));
 
     #[allow(clippy::as_conversions)]
     /// [NodeIndex] constant that represents the largest index in a tree.
     // TODO(Tzahi, 15/6/2024): Support height < 128 bits.
     pub const MAX: Self = Self(U256::from_words(
-        u128::MAX >> (U256::BITS - Self::BITS as u32),
+        u128::MAX >> (U256::BITS - (TreeHeight::MAX.0 + 1) as u32),
         u128::MAX,
     ));
 
@@ -81,13 +83,13 @@ impl NodeIndex {
 
     /// Returns the number of leading zeroes when represented with Self::BITS bits.
     pub(crate) fn leading_zeros(&self) -> u8 {
-        (self.0.leading_zeros() - (U256::BITS - u32::from(Self::BITS)))
+        (self.0.leading_zeros() - (U256::BITS - u32::from(TreeHeight::ACTUAL_HEIGHT.0 + 1)))
             .try_into()
             .expect("Leading zeroes are unexpectedly larger than a u8.")
     }
 
     pub(crate) fn bit_length(&self) -> u8 {
-        Self::BITS - self.leading_zeros()
+        TreeHeight::ACTUAL_HEIGHT.0 + 1 - self.leading_zeros()
     }
 
     #[allow(dead_code)]

--- a/crates/committer/src/patricia_merkle_tree/types_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/types_test.rs
@@ -120,7 +120,7 @@ fn test_get_path_to_descendant(
 #[rstest]
 fn test_get_path_to_descendant_big() {
     let root_index = NodeIndex(U256::from(rand::thread_rng().gen::<u128>()));
-    let max_bits = NodeIndex::BITS - 128;
+    let max_bits = TreeHeight::ACTUAL_HEIGHT.0 + 1 - 128;
     let extension: u128 = rand::thread_rng().gen_range(0..1 << max_bits);
     let extension_index = NodeIndex(U256::from(extension));
 

--- a/crates/committer/src/patricia_merkle_tree/updated_skeleton_tree/compute_updated_skeleton_tree_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/updated_skeleton_tree/compute_updated_skeleton_tree_test.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 #[fixture]
 fn updated_skeleton(
-    #[default(TreeHeight::MAX)] tree_height: TreeHeight,
+    #[default(TreeHeight::ACTUAL_HEIGHT)] tree_height: TreeHeight,
     #[default(&[])] leaf_modifications: &[(U256, u8)],
 ) -> UpdatedSkeletonTreeImpl {
     UpdatedSkeletonTreeImpl {
@@ -191,7 +191,8 @@ fn test_node_from_binary_data(
     #[case] _leaf_modifications: &[(U256, u8)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
-    #[with(TreeHeight::MAX, _leaf_modifications)] mut updated_skeleton: UpdatedSkeletonTreeImpl,
+    #[with(TreeHeight::ACTUAL_HEIGHT, _leaf_modifications)]
+    mut updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
     let mut expected_skeleton_tree = updated_skeleton.skeleton_tree.clone();
     expected_skeleton_tree.extend(expected_skeleton_additions.iter().cloned());
@@ -258,7 +259,8 @@ fn test_node_from_edge_data(
     #[case] _leaf_modifications: &[(U256, u8)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
-    #[with(TreeHeight::MAX, _leaf_modifications)] mut updated_skeleton: UpdatedSkeletonTreeImpl,
+    #[with(TreeHeight::ACTUAL_HEIGHT, _leaf_modifications)]
+    mut updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
     let mut expected_skeleton_tree = updated_skeleton.skeleton_tree.clone();
     expected_skeleton_tree.extend(expected_skeleton_additions.iter().cloned());
@@ -299,7 +301,8 @@ fn test_update_node_in_empty_tree(
     #[case] leaf_modifications: &[(U256, u8)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
-    #[with(TreeHeight::MAX, leaf_modifications)] mut updated_skeleton: UpdatedSkeletonTreeImpl,
+    #[with(TreeHeight::ACTUAL_HEIGHT, leaf_modifications)]
+    mut updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
     let leaf_indices: Vec<NodeIndex> = leaf_modifications
         .iter()
@@ -387,7 +390,8 @@ fn test_update_node_in_nonempty_tree(
     #[case] leaf_modifications: &[(U256, u8)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
-    #[with(TreeHeight::MAX, leaf_modifications)] mut updated_skeleton: UpdatedSkeletonTreeImpl,
+    #[with(TreeHeight::ACTUAL_HEIGHT, leaf_modifications)]
+    mut updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
     let leaf_indices: Vec<NodeIndex> = leaf_modifications
         .iter()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/167)
<!-- Reviewable:end -->
