### PR TITLE
refactor: remove dependency on a given tree height of original skeletons

### DIFF
--- a/crates/committer/src/patricia_merkle_tree/types.rs
+++ b/crates/committer/src/patricia_merkle_tree/types.rs
@@ -157,6 +157,16 @@ impl NodeIndex {
     fn from_felt_value(felt: &Felt) -> Self {
         Self(U256::from(felt))
     }
+
+    #[cfg(test)]
+    /// Assumes self represents an index in a smaller tree height. Returns a node index represents
+    /// the same index in the starknet state tree as if the smaller tree was 'planted' at the lowest
+    /// leftmost node from the root.
+    pub(crate) fn from_subtree_index(subtree_index: Self, subtree_height: TreeHeight) -> Self {
+        let height_diff = TreeHeight::MAX.0 - subtree_height.0;
+        let offset = (NodeIndex::ROOT << height_diff) - 1.into();
+        subtree_index + (offset << (subtree_index.bit_length() - 1))
+    }
 }
 
 impl std::ops::Add for NodeIndex {


### PR DESCRIPTION
First stage of the tree height refactor.
Small trees are now 'large' with an edge node to the root of the small tree.
Next stage is to remove the tree_height parameter inside original skeleton

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/179)
<!-- Reviewable:end -->
