### PR TITLE
refactor: change the hierarchy between test and testing

### DIFF
--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -24,7 +24,6 @@ derive_more.workspace = true
 ethnum.workspace = true
 hex.workspace = true
 rand.workspace = true
-rstest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true

--- a/crates/committer/Cargo.toml
+++ b/crates/committer/Cargo.toml
@@ -31,3 +31,6 @@ strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+
+[target.'cfg(test)'.features]
+default = ["testing"]

--- a/crates/committer/src/patricia_merkle_tree.rs
+++ b/crates/committer/src/patricia_merkle_tree.rs
@@ -5,5 +5,8 @@ pub mod original_skeleton_tree;
 pub mod types;
 pub mod updated_skeleton_tree;
 
-#[cfg(any(feature = "testing", test))]
-pub mod test_utils;
+#[cfg(test)]
+pub mod internal_test_utils;
+
+#[cfg(feature = "testing")]
+pub mod external_test_utils;

--- a/crates/committer/src/patricia_merkle_tree/external_test_utils.rs
+++ b/crates/committer/src/patricia_merkle_tree/external_test_utils.rs
@@ -1,0 +1,53 @@
+use ethnum::U256;
+
+use crate::felt::Felt;
+use crate::patricia_merkle_tree::errors::TypesError;
+use rand::Rng;
+
+impl TryFrom<&U256> for Felt {
+    type Error = TypesError<U256>;
+    fn try_from(value: &U256) -> Result<Self, Self::Error> {
+        if *value > U256::from(&Felt::MAX) {
+            return Err(TypesError::ConversionError {
+                from: *value,
+                to: "Felt",
+                reason: "value is bigger than felt::max",
+            });
+        }
+        Ok(Self::from_bytes_be(&value.to_be_bytes()))
+    }
+}
+
+/// Generates a random U256 number between low and high (exclusive).
+/// Panics if low > high
+pub fn get_random_u256<R: Rng>(rng: &mut R, low: U256, high: U256) -> U256 {
+    assert!(low < high);
+    let high_of_low = low.high();
+    let high_of_high = high.high();
+
+    let delta = high - low;
+    if delta <= u128::MAX {
+        let delta = u128::try_from(delta).expect("Failed to convert delta to u128");
+        return low + rng.gen_range(0..delta);
+    }
+
+    // Randomize the high 128 bits in the extracted range, and the low 128 bits in their entire
+    // domain until the result is in range.
+    // As high-low>u128::MAX, the expected number of samples until the loops breaks is bound from
+    // above by 3 (as either:
+    //  1. high_of_high > high_of_low + 1, and there is a 1/3 chance to get a valid result for high
+    //  bits in (high_of_low, high_of_high).
+    //  2. high_of_high == high_of_low + 1, and every possible low 128 bits value is valid either
+    // when the high bits equal high_of_high, or when they equal high_of_low).
+    let mut randomize = || {
+        U256::from_words(
+            rng.gen_range(*high_of_low..=*high_of_high),
+            rng.gen_range(0..=u128::MAX),
+        )
+    };
+    let mut result = randomize();
+    while result < low || result >= high {
+        result = randomize();
+    }
+    result
+}

--- a/crates/committer/src/patricia_merkle_tree/internal_test_utils.rs
+++ b/crates/committer/src/patricia_merkle_tree/internal_test_utils.rs
@@ -1,25 +1,10 @@
 use crate::felt::Felt;
-use crate::patricia_merkle_tree::errors::TypesError;
+use crate::patricia_merkle_tree::external_test_utils::get_random_u256;
 use crate::patricia_merkle_tree::node_data::inner_node::{EdgePathLength, PathToBottom};
 use crate::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
 use ethnum::U256;
 use rand::rngs::ThreadRng;
-use rand::Rng;
 use rstest::{fixture, rstest};
-
-impl TryFrom<&U256> for Felt {
-    type Error = TypesError<U256>;
-    fn try_from(value: &U256) -> Result<Self, Self::Error> {
-        if *value > U256::from(&Felt::MAX) {
-            return Err(TypesError::ConversionError {
-                from: *value,
-                to: "Felt",
-                reason: "value is bigger than felt::max",
-            });
-        }
-        Ok(Self::from_bytes_be(&value.to_be_bytes()))
-    }
-}
 
 impl From<u8> for SkeletonLeaf {
     fn from(value: u8) -> Self {
@@ -49,10 +34,8 @@ pub(crate) fn random() -> ThreadRng {
     rand::thread_rng()
 }
 
-#[cfg(test)]
 use crate::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
 
-#[cfg(test)]
 impl NodeIndex {
     /// Assumes self represents an index in a smaller tree height. Returns a node index represents
     /// the same index in the starknet state tree as if the smaller tree was 'planted' at the lowest
@@ -64,43 +47,8 @@ impl NodeIndex {
     }
 }
 
-#[cfg(test)]
 pub(crate) fn small_tree_index_to_full(index: U256, height: SubTreeHeight) -> NodeIndex {
     NodeIndex::from_subtree_index(NodeIndex::new(index), height)
-}
-/// Generates a random U256 number between low and high (exclusive).
-/// Panics if low > high.
-#[cfg(any(feature = "testing", test))]
-pub fn get_random_u256<R: Rng>(rng: &mut R, low: U256, high: U256) -> U256 {
-    assert!(low < high);
-    let high_of_low = low.high();
-    let high_of_high = high.high();
-
-    let delta = high - low;
-    if delta <= u128::MAX {
-        let delta = u128::try_from(delta).expect("Failed to convert delta to u128");
-        return low + rng.gen_range(0..delta);
-    }
-
-    // Randomize the high 128 bits in the extracted range, and the low 128 bits in their entire
-    // domain until the result is in range.
-    // As high-low>u128::MAX, the expected number of samples until the loops breaks is bound from
-    // above by 3 (as either:
-    //  1. high_of_high > high_of_low + 1, and there is a 1/3 chance to get a valid result for high
-    //  bits in (high_of_low, high_of_high).
-    //  2. high_of_high == high_of_low + 1, and every possible low 128 bits value is valid either
-    // when the high bits equal high_of_high, or when they equal high_of_low).
-    let mut randomize = || {
-        U256::from_words(
-            rng.gen_range(*high_of_low..=*high_of_high),
-            rng.gen_range(0..=u128::MAX),
-        )
-    };
-    let mut result = randomize();
-    while result < low || result >= high {
-        result = randomize();
-    }
-    result
 }
 
 #[rstest]
@@ -115,7 +63,6 @@ fn test_get_random_u256(mut random: ThreadRng, #[case] low: U256, #[case] high: 
     assert!(low <= r && r < high);
 }
 
-#[cfg(test)]
 pub(crate) fn as_fully_indexed(
     subtree_height: u8,
     indices: impl Iterator<Item = U256>,

--- a/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/utils_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/original_skeleton_tree/utils_test.rs
@@ -1,8 +1,8 @@
 use super::split_leaves;
-use crate::patricia_merkle_tree::test_utils::as_fully_indexed;
-use crate::patricia_merkle_tree::test_utils::get_random_u256;
-use crate::patricia_merkle_tree::test_utils::random;
-use crate::patricia_merkle_tree::test_utils::small_tree_index_to_full;
+use crate::patricia_merkle_tree::external_test_utils::get_random_u256;
+use crate::patricia_merkle_tree::internal_test_utils::as_fully_indexed;
+use crate::patricia_merkle_tree::internal_test_utils::random;
+use crate::patricia_merkle_tree::internal_test_utils::small_tree_index_to_full;
 use crate::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
 use ethnum::{uint, U256};
 use rand::rngs::ThreadRng;

--- a/crates/committer/src/patricia_merkle_tree/types_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/types_test.rs
@@ -1,12 +1,12 @@
 use crate::block_committer::input::{ContractAddress, StarknetStorageKey};
 use crate::felt::Felt;
+use crate::patricia_merkle_tree::external_test_utils::get_random_u256;
+use crate::patricia_merkle_tree::internal_test_utils::random;
 use crate::patricia_merkle_tree::node_data::inner_node::{EdgePathLength, PathToBottom};
-use crate::patricia_merkle_tree::test_utils::{get_random_u256, random};
 use crate::patricia_merkle_tree::types::NodeIndex;
 
-use rand::rngs::ThreadRng;
-
 use ethnum::{uint, U256};
+use rand::rngs::ThreadRng;
 use rand::Rng;
 use rstest::rstest;
 

--- a/crates/committer/src/patricia_merkle_tree/updated_skeleton_tree/compute_updated_skeleton_tree_test.rs
+++ b/crates/committer/src/patricia_merkle_tree/updated_skeleton_tree/compute_updated_skeleton_tree_test.rs
@@ -6,11 +6,11 @@ use std::collections::HashMap;
 use crate::felt::Felt;
 use crate::hash::hash_trait::HashOutput;
 use crate::patricia_merkle_tree::filled_tree::tree::{FilledTree, FilledTreeImpl};
+use crate::patricia_merkle_tree::internal_test_utils::small_tree_index_to_full;
 use crate::patricia_merkle_tree::node_data::inner_node::{EdgePathLength, PathToBottom};
 use crate::patricia_merkle_tree::original_skeleton_tree::node::OriginalSkeletonNode;
 use crate::patricia_merkle_tree::original_skeleton_tree::tree::OriginalSkeletonNodeMap;
 use crate::patricia_merkle_tree::original_skeleton_tree::tree::OriginalSkeletonTreeImpl;
-use crate::patricia_merkle_tree::test_utils::small_tree_index_to_full;
 use crate::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
 use crate::patricia_merkle_tree::updated_skeleton_tree::compute_updated_skeleton_tree::{
     get_path_to_lca, has_leaves_on_both_sides, TempSkeletonNode,
@@ -310,7 +310,7 @@ fn test_node_from_edge_data(
     TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
     &[
         (NodeIndex::from(2),
-        UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(250).as_str()))), 
+        UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(250).as_str()))),
         (NodeIndex::from(3),
         UpdatedSkeletonNode::Edge(PathToBottom::from("1".repeat(250).as_str())))],
 )]

--- a/crates/committer_cli/src/tests/utils/random_structs.rs
+++ b/crates/committer_cli/src/tests/utils/random_structs.rs
@@ -1,6 +1,7 @@
 use committer::block_committer::input::ContractAddress;
 use committer::felt::Felt;
 use committer::hash::hash_trait::HashOutput;
+use committer::patricia_merkle_tree::external_test_utils::get_random_u256;
 use committer::patricia_merkle_tree::filled_tree::forest::FilledForestImpl;
 use committer::patricia_merkle_tree::filled_tree::node::ClassHash;
 use committer::patricia_merkle_tree::filled_tree::node::CompiledClassHash;
@@ -16,7 +17,6 @@ use committer::patricia_merkle_tree::node_data::inner_node::{
 use committer::patricia_merkle_tree::node_data::leaf::ContractState;
 use committer::patricia_merkle_tree::node_data::leaf::LeafDataImpl;
 use committer::patricia_merkle_tree::node_data::leaf::LeafDataImplDiscriminants as LeafDataVariants;
-use committer::patricia_merkle_tree::test_utils::get_random_u256;
 use committer::patricia_merkle_tree::types::NodeIndex;
 use ethnum::U256;
 use rand::prelude::IteratorRandom;


### PR DESCRIPTION
Separate between test and testing. Now, the test depends on testing, meaning that cfg(test) also compiles the testing file, 
but testing does not include a test file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/committer/211)
<!-- Reviewable:end -->
